### PR TITLE
feat: php variable completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This coc-extension will provide various completion features and more features fo
     - PHP Function completion | [DEMO](https://github.com/yaegassy/coc-laravel/issues/1#issuecomment-1643359916)
     - PHP Class completion | [DEMO](https://github.com/yaegassy/coc-laravel/issues/1#issuecomment-1671277304)
     - PHP Scope Resolution completion (e.g. `DateTime::|`) | [DEMO](https://github.com/yaegassy/coc-laravel/issues/1#issuecomment-1674415047)
+    - PHP Variable completion | [DEMO](https://github.com/yaegassy/coc-laravel/issues/1#issuecomment-1676733936)
     - PHP Constant completion | [DESCRIPTION](https://github.com/yaegassy/coc-laravel/issues/1#issuecomment-1671281861)
     - PHP Keyword completion | [DESCRIPTION](https://github.com/yaegassy/coc-laravel/issues/1#issuecomment-1671284071)
   - Directive completion | [DEMO](https://github.com/yaegassy/coc-laravel/issues/1#issuecomment-1657000532)
@@ -145,6 +146,8 @@ For more information, check this coc.nvim's wiki.
 - `laravel.completion.componentEnable`: Enable component completion, default: `true`
 - `laravel.completion.phpFunctionEnable`: Enable php function completion, default: `true`
 - `laravel.completion.phpClassEnable`: Enable php class completion, default: `true`
+- `laravel.completion.phpScopeResolutionEnable`: Enable php scope resolution completion, default: `true`
+- `laravel.completion.phpVariableEnable`: Enable php variable completion, default: `true`
 - `laravel.completion.phpConstantEnable`: Enable php constant completion, default: `true`
 - `laravel.completion.phpKeywordEnable`: Enable php keyword completion, default: `true`
 - `laravel.completion.methodParameterEnable`: Enable method parameter completion, default: `true`

--- a/package.json
+++ b/package.json
@@ -282,6 +282,11 @@
           "default": true,
           "description": "Enable php scope resolution completion."
         },
+        "laravel.completion.phpVariableEnable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable php variable completion."
+        },
         "laravel.completion.phpConstantEnable": {
           "type": "boolean",
           "default": true,

--- a/src/__tests__/phpVariable.test.ts
+++ b/src/__tests__/phpVariable.test.ts
@@ -1,0 +1,278 @@
+import { test, expect } from 'vitest';
+
+import * as bladeParser from '../parsers/blade/parser';
+import * as testUtils from './testUtils';
+
+import * as bladeCommon from '../common/blade';
+import { PhpVariableItemType } from '../common/types';
+
+type PhpRelatedBladeNodeType = 'inlinePhp' | 'phpDirective';
+
+type VariableItemType = {
+  name: string;
+  start: number;
+  end: number;
+  bladeNodeStart?: number;
+  bladeNodeEnd?: number;
+  bladeNodeType?: PhpRelatedBladeNodeType;
+};
+
+test('Get variable data items from the blade php-related node type', async () => {
+  const code = testUtils.stripInitialNewline(`
+<p>Dummy1</p>
+<?php
+    $inlineVar = "sample1Value";
+    $inlineValueVar = $sample1;
+?>
+
+<p>Dummy2</p>
+
+@php
+    $directiveVar = "sample3Value";
+@endphp
+
+<p>Dummy3</p>
+
+@php($shortDirectiveInt = 1)
+@php($shortDirectiveBool = false)
+
+<p>Dummy4</p>
+
+<?php
+    $inlineVar = "2023/08/14"
+    $inlineObj = DateTime($date);
+?>
+`);
+
+  const bladeDoc = bladeParser.getBladeDocument(code);
+  if (!bladeDoc) return;
+
+  const variableItems: VariableItemType[] = [];
+
+  const inlinePhpVariableItems = bladeCommon.getVariableItemsWithBladeRangeOffsetsFromBladeDoc(bladeDoc, 'inlinePhp');
+  if (inlinePhpVariableItems.length > 0) variableItems.push(...inlinePhpVariableItems);
+
+  const phpDirectiveVariableItems = bladeCommon.getVariableItemsWithBladeRangeOffsetsFromBladeDoc(
+    bladeDoc,
+    'phpDirective'
+  );
+  if (phpDirectiveVariableItems.length > 0) variableItems.push(...phpDirectiveVariableItems);
+
+  const expected = [
+    {
+      name: 'inlineVar',
+      type: 'string',
+      start: 10,
+      end: 20,
+      bladeNodeStart: 14,
+      bladeNodeEnd: 86,
+      bladeNodeType: 'inlinePhp',
+    },
+    {
+      name: 'inlineValueVar',
+      type: 'variable',
+      start: 43,
+      end: 58,
+      bladeNodeStart: 14,
+      bladeNodeEnd: 86,
+      bladeNodeType: 'inlinePhp',
+    },
+    {
+      name: 'inlineVar',
+      type: 'string',
+      start: 10,
+      end: 20,
+      bladeNodeStart: 248,
+      bladeNodeEnd: 319,
+      bladeNodeType: 'inlinePhp',
+    },
+    {
+      name: 'inlineObj',
+      type: 'call',
+      start: 40,
+      end: 50,
+      bladeNodeStart: 248,
+      bladeNodeEnd: 319,
+      bladeNodeType: 'inlinePhp',
+    },
+    {
+      name: 'directiveVar',
+      type: 'string',
+      start: 10,
+      end: 23,
+      bladeNodeStart: 104,
+      bladeNodeEnd: 152,
+      bladeNodeType: 'phpDirective',
+    },
+    {
+      name: 'shortDirectiveInt',
+      type: 'int',
+      start: 7,
+      end: 25,
+      bladeNodeStart: 170,
+      bladeNodeEnd: 197,
+      bladeNodeType: 'phpDirective',
+    },
+    {
+      name: 'shortDirectiveBool',
+      type: 'false',
+      start: 7,
+      end: 26,
+      bladeNodeStart: 199,
+      bladeNodeEnd: 231,
+      bladeNodeType: 'phpDirective',
+    },
+  ];
+
+  expect(variableItems).toMatchObject(expected);
+});
+
+test('Get the adjust offset from the php-related node type of the blade', async () => {
+  const a1 = bladeCommon.getAdjustOffsetAtBladeNodeTypeString('inlinePhp');
+  expect(a1).toBe(0);
+
+  const a2 = bladeCommon.getAdjustOffsetAtBladeNodeTypeString('phpDirective');
+  expect(a2).toBe(-1);
+});
+
+test('Get variable data items that can be completed from the editor offset', async () => {
+  const phpVariableItems: PhpVariableItemType[] = [
+    {
+      name: 'inlineVar',
+      type: 'string',
+      start: 10,
+      end: 20,
+      bladeNodeStart: 14,
+      bladeNodeEnd: 86,
+      bladeNodeType: 'inlinePhp',
+    },
+    {
+      name: 'shortDirectiveInt',
+      type: 'int',
+      start: 7,
+      end: 25,
+      bladeNodeStart: 170,
+      bladeNodeEnd: 197,
+      bladeNodeType: 'phpDirective',
+    },
+  ];
+
+  let editorOffset = 0;
+
+  // 1
+  editorOffset = 33;
+  const a1 = bladeCommon.getVariableItemsFromEditorOffset(phpVariableItems, editorOffset);
+
+  const e1 = [
+    // [Not Listed] | 20 (end) + 14 (bladeNodeStart) + 0 (adjustOffset) <= 33 (editorOffset)
+    //{
+    //  name: 'inlineVar',
+    //  type: 'string',
+    //},
+    // [Not Listed] | 25 (end) + 170 (bladeNodeStart) - 1 (adjustOffset) <= 33 (editorOffset)
+    //{
+    //  name: 'shortDirectiveInt',
+    //  type: 'int',
+    //},
+  ];
+  expect(a1).toMatchObject(e1);
+
+  // 2
+  editorOffset = 34;
+  const a2 = bladeCommon.getVariableItemsFromEditorOffset(phpVariableItems, editorOffset);
+
+  const e2 = [
+    // [Listed] | 20 (end) + 14 (bladeNodeStart) + 0 (adjustOffset) <= 34 (editorOffset)
+    {
+      name: 'inlineVar',
+      type: 'string',
+    },
+    // [Not Listed] | 25 (end) + 170 (bladeNodeStart) - 1 (adjustOffset) <= 34 (editorOffset)
+    //{
+    //  name: 'shortDirectiveInt',
+    //  type: 'int',
+    //},
+  ];
+  expect(a2).toMatchObject(e2);
+
+  // 3
+  editorOffset = 193;
+  const a3 = bladeCommon.getVariableItemsFromEditorOffset(phpVariableItems, editorOffset);
+
+  const e3 = [
+    // [Listed] | 20 (end) + 14 (bladeNodeStart) + 0 (adjustOffset) <= 193 (editorOffset)
+    {
+      name: 'inlineVar',
+      type: 'string',
+    },
+    // [Not Listed] | 25 (end) + 170 (bladeNodeStart) - 1 (adjustOffset) <= 193 (editorOffset)
+    //{
+    //  name: 'shortDirectiveInt',
+    //  type: 'int',
+    //},
+  ];
+  expect(a3).toMatchObject(e3);
+
+  // 4
+  editorOffset = 194;
+  const a4 = bladeCommon.getVariableItemsFromEditorOffset(phpVariableItems, editorOffset);
+
+  const e4 = [
+    // [Listed] | 20 (end) + 14 (bladeNodeStart) + 0 (adjustOffset) <= 194 (editorOffset)
+    {
+      name: 'inlineVar',
+      type: 'string',
+    },
+    // [Listed] | 25 (end) + 170 (bladeNodeStart) - 1 (adjustOffset) <= 194 (editorOffset)
+    {
+      name: 'shortDirectiveInt',
+      type: 'int',
+    },
+  ];
+  expect(a4).toMatchObject(e4);
+});
+
+test('Testing virtual php eval code', async () => {
+  const code = testUtils.stripInitialNewline(`
+<p>Dummy1</p>
+<?php
+    $inlineVar = "sample1Value";
+    $inlineValueVar = $sample1;
+?>
+
+<p>Dummy2</p>
+
+@php
+    $directiveVar = "sample3Value";
+@endphp
+
+<p>Dummy3</p>
+
+@php($shortDirectiveInt = 1)
+@php($shortDirectiveBool = false)
+
+<p>Dummy4</p>
+
+<?php
+    $inlineVar = "2023/08/14";
+    $inlineObj = DateTime($date);
+?>
+`);
+
+  const actual = bladeCommon.generateVirtualPhpEvalCode(code);
+
+  const expected = `
+    $inlineVar = "sample1Value";
+    $inlineValueVar = $sample1;
+
+    $directiveVar = "sample3Value";
+
+$shortDirectiveInt = 1;
+$shortDirectiveBool = false;
+
+    $inlineVar = "2023/08/14";
+    $inlineObj = DateTime($date);
+`;
+
+  expect(actual).toMatchObject(expected);
+});

--- a/src/__tests__/tinkerReflection.test.ts
+++ b/src/__tests__/tinkerReflection.test.ts
@@ -347,3 +347,29 @@ echo json_encode(\\$staticMethod->__toString());
     expect(staticMethodData2).toBe(expected2);
   });
 });
+
+describe('PHP variable related', () => {
+  test('Get information about an object from a variable', async () => {
+    const rootDir = testUtils.TEST_LV_PROJECT_PATH;
+    const artisanPath = testUtils.getArtisanPath(rootDir)!;
+
+    // $ -> \\$
+    const code = testUtils.stripInitialNewline(`
+\\$date = \\"2023/08/14\\";
+\\$now = new DateTime(\\$date);
+
+try {
+    if (isset(\\$now)) {
+        \\$reflector = new ReflectionObject(\\$now);
+        echo json_encode(\\$reflector->name);
+    }
+} catch (\\Throwable \\$th) {}
+`);
+
+    const resJsonStr = await testUtils.runTinkerReflection(code, artisanPath)!;
+    if (!resJsonStr) return;
+    const detectVariableType = JSON.parse(resJsonStr) as string;
+
+    expect(detectVariableType).toBe('DateTime');
+  });
+});

--- a/src/common/blade.ts
+++ b/src/common/blade.ts
@@ -1,0 +1,165 @@
+import { Assign, Boolean as BooleanNode, Variable } from 'php-parser';
+import { BladeDocument } from 'stillat-blade-parser/out/document/bladeDocument';
+import { DirectiveNode, InlinePhpNode } from 'stillat-blade-parser/out/nodes/nodes';
+
+import * as phpParser from '../parsers/php/parser';
+import * as bladeParser from '../parsers/blade/parser';
+import { PhpRelatedBladeNodeType, PhpVariableItemType } from './types';
+
+export function getVariableItemsWithBladeRangeOffsetsFromBladeDoc(
+  bladeDoc: BladeDocument,
+  bladeNodeTypeString: PhpRelatedBladeNodeType
+) {
+  const items: PhpVariableItemType[] = [];
+
+  for (const bladeNode of bladeDoc.getAllNodes()) {
+    let bladeStartOffset: number | undefined = undefined;
+    let bladeEndOffset: number | undefined = undefined;
+    let phpCode: string | undefined = undefined;
+
+    if (bladeNodeTypeString === 'inlinePhp') {
+      if (!(bladeNode instanceof InlinePhpNode)) continue;
+      if (bladeNode.startPosition && !bladeNode.endPosition) continue;
+      bladeStartOffset = bladeNode.startPosition?.offset;
+      bladeEndOffset = bladeNode.endPosition?.offset;
+      phpCode = bladeNode.sourceContent;
+    } else if (bladeNodeTypeString === 'phpDirective') {
+      if (!(bladeNode instanceof DirectiveNode)) continue;
+      if (!bladeNode.startPosition && !bladeNode.endPosition) continue;
+
+      const endPhpDirectiveNode = bladeNode.getFinalClosingDirective();
+      if (endPhpDirectiveNode.directiveName === 'endphp') {
+        if (bladeNode.directiveName === 'endphp') continue;
+        if (!endPhpDirectiveNode.offset?.end) continue;
+
+        bladeStartOffset = bladeNode.offset?.start;
+        bladeEndOffset = endPhpDirectiveNode.offset.end;
+        phpCode = '<?php' + bladeNode.innerContent;
+      } else if (endPhpDirectiveNode.directiveName === 'php') {
+        bladeStartOffset = bladeNode.startPosition?.offset;
+        bladeEndOffset = bladeNode.endPosition?.offset;
+        phpCode = '<?php ' + bladeNode.getPhpContent();
+      }
+    }
+
+    if (!bladeStartOffset) continue;
+    if (!bladeEndOffset) continue;
+    if (!phpCode) continue;
+
+    const phpAst = phpParser.getAstByParseCode(phpCode);
+    if (!phpAst) continue;
+
+    phpParser.walk((phpNode, parent) => {
+      if (!parent) return;
+      if (parent.kind !== 'expressionstatement') return;
+      if (phpNode.kind !== 'assign') return;
+      const assignNode = phpNode as Assign;
+
+      if (assignNode.left.kind !== 'variable') return;
+      const variableNode = assignNode.left as Variable;
+
+      if (typeof variableNode.name !== 'string') return;
+      if (!variableNode.loc) return;
+
+      let variableType: string | undefined = undefined;
+      if (assignNode.right.kind === 'string') {
+        variableType = 'string';
+      } else if (assignNode.right.kind === 'boolean') {
+        const valueBooleanNode = assignNode.right as BooleanNode;
+        variableType = String(valueBooleanNode.value);
+      } else if (assignNode.right.kind === 'number') {
+        variableType = 'int';
+      } else if (assignNode.right.kind === 'nullkeyword') {
+        variableType = 'null';
+      } else if (assignNode.right.kind === 'array') {
+        variableType = 'array';
+      } else if (assignNode.right.kind === 'call') {
+        variableType = 'call';
+      } else if (assignNode.right.kind === 'new') {
+        variableType = 'new';
+      } else if (assignNode.right.kind === 'variable') {
+        variableType = 'variable';
+      } else {
+        variableType = 'object';
+      }
+
+      items.push({
+        name: variableNode.name,
+        type: variableType,
+        start: variableNode.loc.start.offset,
+        end: variableNode.loc.end.offset,
+        bladeNodeStart: bladeStartOffset,
+        bladeNodeEnd: bladeEndOffset,
+        bladeNodeType: bladeNodeTypeString,
+      });
+    }, phpAst);
+  }
+
+  return items;
+}
+
+export function getAdjustOffsetAtBladeNodeTypeString(bladeNodeTypeString: PhpRelatedBladeNodeType) {
+  let adjustOffset: number;
+
+  switch (bladeNodeTypeString) {
+    case 'inlinePhp':
+      adjustOffset = 0;
+      break;
+
+    case 'phpDirective':
+      adjustOffset = -1;
+      break;
+
+    default:
+      adjustOffset = 0;
+      break;
+  }
+
+  return adjustOffset;
+}
+
+export function getVariableItemsFromEditorOffset(phpVariableItems: PhpVariableItemType[], editorOffset: number) {
+  const items: { name: string; type: string }[] = [];
+
+  for (const v of phpVariableItems) {
+    if (!v.bladeNodeType) continue;
+    if (!v.bladeNodeStart) continue;
+
+    const adjustOffset = getAdjustOffsetAtBladeNodeTypeString(v.bladeNodeType);
+    if (adjustOffset == null) continue;
+
+    const realEndOffset = v.end + v.bladeNodeStart + adjustOffset;
+
+    if (realEndOffset <= editorOffset) {
+      items.push({
+        name: v.name,
+        type: v.type,
+      });
+    }
+  }
+
+  return items;
+}
+
+export function generateVirtualPhpEvalCode(code: string) {
+  let virtualPhpCode: string = '';
+
+  const bladeDoc = bladeParser.getBladeDocument(code);
+  if (!bladeDoc) return;
+
+  for (const bladeNode of bladeDoc.getAllNodes()) {
+    if (bladeNode instanceof InlinePhpNode) {
+      virtualPhpCode += phpParser.stripPHPTag(bladeNode.sourceContent);
+    } else if (bladeNode instanceof DirectiveNode) {
+      const endPhpDirectiveNode = bladeNode.getFinalClosingDirective();
+      if (endPhpDirectiveNode.directiveName === 'endphp') {
+        if (bladeNode.directiveName === 'endphp') continue;
+        virtualPhpCode += bladeNode.innerContent + '\n';
+      } else if (endPhpDirectiveNode.directiveName === 'php') {
+        virtualPhpCode += bladeNode.getPhpContent().replace(/^\(/, '').replace(/\)$/, ';') + '\n';
+      }
+    }
+  }
+
+  return virtualPhpCode;
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -64,3 +64,15 @@ export type BladeWithPhpScopeResolutionItemsType = {
   end: number;
   scopeResolutionItems: ScopeResolutionItemType[];
 };
+
+export type PhpRelatedBladeNodeType = 'inlinePhp' | 'phpDirective';
+
+export type PhpVariableItemType = {
+  name: string;
+  type: string;
+  start: number;
+  end: number;
+  bladeNodeStart?: number;
+  bladeNodeEnd?: number;
+  bladeNodeType?: PhpRelatedBladeNodeType;
+};

--- a/src/common/utils.ts
+++ b/src/common/utils.ts
@@ -9,3 +9,7 @@ export function elapsed(start: [number, number]) {
 export function stripInitialNewline(text: string) {
   return text.replace(/^\n/, '');
 }
+
+export function quoteForTerminalExecution(text: string) {
+  return text.replace(/\$/g, '\\$').replace(/"/g, '\\"').replace(/\\/g, '\\');
+}

--- a/src/completions/completion.ts
+++ b/src/completions/completion.ts
@@ -40,6 +40,7 @@ import * as phpConstantCompletionHandler from './handlers/phpConstantHandler';
 import * as phpFunctionCompletionHandler from './handlers/phpFunctionHandler';
 import * as phpKeywordCompletionHandler from './handlers/phpKeywordHandler';
 import * as phpScopeResolutionCompletionHandler from './handlers/phpScopeResolutionHandler';
+import * as phpVariableCompletionHandler from './handlers/phpVariableHandler';
 import * as routeCompletionHandler from './handlers/routeHandler';
 import * as translationCompletionHandler from './handlers/translationHandler';
 import * as validationCompletionHandler from './handlers/validationHandler';
@@ -291,6 +292,14 @@ class LaravelCompletionProvider implements CompletionItemProvider {
       }
     }
 
+    // php variable
+    if (config.completion.phpVariableEnable) {
+      const phpVariableCompletionItems = await phpVariableCompletionHandler.doCompletion(document, position);
+      if (phpVariableCompletionItems) {
+        items.push(...phpVariableCompletionItems);
+      }
+    }
+
     // php constant
     if (config.completion.phpConstantEnable) {
       const phpConstantCompletionItems = await phpConstantCompletionHandler.doCompletion(
@@ -415,6 +424,9 @@ class LaravelCompletionProvider implements CompletionItemProvider {
         _token,
         this.artisanPath
       );
+      return resolveItem;
+    } else if (itemData.source === 'laravel-php-variable') {
+      const resolveItem = await phpVariableCompletionHandler.doResolveCompletionItem(item, _token, this.artisanPath);
       return resolveItem;
     }
 

--- a/src/completions/handlers/phpVariableHandler.ts
+++ b/src/completions/handlers/phpVariableHandler.ts
@@ -1,0 +1,160 @@
+import {
+  CancellationToken,
+  CompletionItem,
+  CompletionItemKind,
+  InsertTextFormat,
+  LinesTextDocument,
+  Position,
+  TextEdit,
+  workspace,
+} from 'coc.nvim';
+
+import * as bladeCommon from '../../common/blade';
+import { runTinkerReflection } from '../../common/shared';
+import { PhpVariableItemType } from '../../common/types';
+import { quoteForTerminalExecution, stripInitialNewline } from '../../common/utils';
+import * as bladeParser from '../../parsers/blade/parser';
+import * as phpVariableCompletionService from '../services/phpVariableService';
+import { CompletionItemDataType } from '../types';
+
+export async function doCompletion(document: LinesTextDocument, position: Position) {
+  if (document.languageId !== 'blade') return [];
+
+  const items: CompletionItem[] = [];
+
+  const doc = workspace.getDocument(document.uri);
+  if (!doc) return [];
+
+  const code = document.getText();
+  const offset = document.offsetAt(position);
+
+  if (!phpVariableCompletionService.canCompletionFromContext(code, offset)) return [];
+
+  let wordWithExtraChars: string | undefined = undefined;
+  const wordWithExtraCharsRange = doc.getWordRangeAtPosition(
+    Position.create(position.line, position.character - 1),
+    '_$'
+  );
+  if (wordWithExtraCharsRange) {
+    wordWithExtraChars = document.getText(wordWithExtraCharsRange);
+  }
+  if (!wordWithExtraChars) return [];
+
+  const variableCompletionItems = getVariableCompletionItems(code, position, offset, wordWithExtraChars);
+
+  if (variableCompletionItems.length > 0) {
+    items.push(...variableCompletionItems);
+  }
+
+  return items;
+}
+
+function getVariableCompletionItems(
+  code: string,
+  position: Position,
+  editorOffset: number,
+  wordWithExtraChars: string
+) {
+  const items: CompletionItem[] = [];
+
+  const bladeDoc = bladeParser.getBladeDocument(code);
+  if (!bladeDoc) return [];
+
+  const phpVariableItems: PhpVariableItemType[] = [];
+
+  const inlinePhpVariableItems = bladeCommon.getVariableItemsWithBladeRangeOffsetsFromBladeDoc(bladeDoc, 'inlinePhp');
+  if (inlinePhpVariableItems.length > 0) phpVariableItems.push(...inlinePhpVariableItems);
+
+  const phpDirectiveVariableItems = bladeCommon.getVariableItemsWithBladeRangeOffsetsFromBladeDoc(
+    bladeDoc,
+    'phpDirective'
+  );
+  if (phpDirectiveVariableItems.length > 0) phpVariableItems.push(...phpDirectiveVariableItems);
+
+  const variableItems = bladeCommon.getVariableItemsFromEditorOffset(phpVariableItems, editorOffset);
+
+  for (const v of variableItems) {
+    const adjustStartCharacter = wordWithExtraChars
+      ? position.character - wordWithExtraChars.length
+      : position.character;
+
+    const edit: TextEdit = {
+      range: {
+        start: { line: position.line, character: adjustStartCharacter },
+        end: position,
+      },
+      newText: '$' + v.name,
+    };
+
+    const data: CompletionItemDataType = {
+      source: 'laravel-php-variable',
+      variableType: v.type,
+      originalContent: code,
+    };
+
+    items.push({
+      label: '$' + v.name,
+      kind: CompletionItemKind.Variable,
+      insertTextFormat: InsertTextFormat.PlainText,
+      commitCharacters: ['$'],
+      textEdit: edit,
+      data,
+    });
+  }
+
+  return items;
+}
+
+export async function doResolveCompletionItem(
+  item: CompletionItem,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _token: CancellationToken,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  artisanPath: string
+) {
+  if (!item.data) return item;
+
+  const itemData = item.data as CompletionItemDataType;
+  if (itemData.source !== 'laravel-php-variable') return item;
+  if (!itemData.variableType) return item;
+
+  if (
+    itemData.variableType === 'variable' ||
+    itemData.variableType === 'call' ||
+    itemData.variableType === 'new' ||
+    itemData.variableType === 'object'
+  ) {
+    item.detail = itemData.variableType;
+
+    if (!itemData.originalContent) return item;
+    const originalContent = itemData.originalContent;
+
+    const virtualPhpCode = bladeCommon.generateVirtualPhpEvalCode(originalContent);
+    if (!virtualPhpCode) return item;
+
+    const quotedVirtualPhpCode = quoteForTerminalExecution(virtualPhpCode);
+
+    const reflectionCode = stripInitialNewline(`
+${quotedVirtualPhpCode}
+
+try {
+    if (isset(\\${item.label})) {
+        \\$reflector = new ReflectionObject(\\${item.label});
+        echo json_encode(\\$reflector->name);
+    }
+} catch (\\Throwable \\$th) {}
+`);
+
+    const resJsonStr = await runTinkerReflection(reflectionCode, artisanPath);
+    if (!resJsonStr) return item;
+
+    const detectVariableType = JSON.parse(resJsonStr) as string;
+    if (!detectVariableType) return item;
+
+    item.detail = detectVariableType;
+  } else {
+    item.detail = itemData.variableType;
+  }
+
+  return item;
+}

--- a/src/completions/services/phpVariableService.ts
+++ b/src/completions/services/phpVariableService.ts
@@ -1,0 +1,28 @@
+import * as bladeParser from '../../parsers/blade/parser';
+
+import {
+  isEditorOffsetInBladeEchoRegionOfPhpNodeKind,
+  isEditorOffsetInDirectiveWithParametersRegionOfPhpNodeKind,
+  isEditorOffsetInInlinePHPRegionOfPhpNodeKind,
+  isEditorOffsetInPHPDirectiveRegionOfPhpNodeKind,
+  isEditorOffsetInPropsValueRegionOfPhpNodeKind,
+} from '../shared';
+
+export function canCompletionFromContext(code: string, editorOffset: number) {
+  const bladeDoc = bladeParser.getBladeDocument(code);
+  if (!bladeDoc) return undefined;
+
+  const flags: boolean[] = [];
+
+  flags.push(isEditorOffsetInBladeEchoRegionOfPhpNodeKind(code, editorOffset, 'variable'));
+  flags.push(isEditorOffsetInPHPDirectiveRegionOfPhpNodeKind(code, editorOffset, 'variable'));
+  flags.push(isEditorOffsetInInlinePHPRegionOfPhpNodeKind(code, editorOffset, 'variable'));
+  flags.push(isEditorOffsetInDirectiveWithParametersRegionOfPhpNodeKind(code, editorOffset, 'variable'));
+  flags.push(isEditorOffsetInPropsValueRegionOfPhpNodeKind(code, editorOffset, 'variable'));
+
+  if (flags.includes(true)) {
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/src/completions/shared.ts
+++ b/src/completions/shared.ts
@@ -1273,8 +1273,6 @@ export function isEditorOffsetInInlinePHPRegionOfPhpNodeKindWithExtraChars(
       const phpAst = phpParser.getAstByParseCode(phpCode);
       if (!phpAst) continue;
 
-      console.log(`=A=: ${phpCode}`);
-
       const kindRangeOffsets: RangeOffset[] = [];
       phpParser.walk((node) => {
         if (node.kind === phpNodeKind) {

--- a/src/completions/types.ts
+++ b/src/completions/types.ts
@@ -25,10 +25,13 @@ export type CompletionItemDataType = {
   kind?: PHPClassItemKindEnum; // phpClass, phpScopeResolution
   isStubs?: boolean; // phpConstant, phpFunction, phpClass, phpScopeResolution
   className?: string; // phpScopeResolution
+  variableType?: string; // phpVariable
+  originalContent?: string; // phpVariable
 };
 
 type CompletionItemSource =
   | 'laravel-php-constant'
   | 'laravel-php-function'
   | 'laravel-php-class'
-  | 'laravel-php-scope-resolution';
+  | 'laravel-php-scope-resolution'
+  | 'laravel-php-variable';

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,5 +10,9 @@ export const config = {
     phpFunctionEnable: _config.get<boolean>('completion.phpFunctionEnable', true),
     phpClassEnable: _config.get<boolean>('completion.phpClassEnable', true),
     phpConstantEnable: _config.get<boolean>('completion.phpConstantEnable', true),
+    get phpVariableEnable() {
+      const defaultValue = true;
+      return _config.get<boolean>('completion.phpVariableEnable', defaultValue);
+    },
   },
 };


### PR DESCRIPTION
this completion feature of variables or objects defined in inline-php region (`<?php ... ?>`) and php-directive region (`@php ... @endphp`) in the blade file. Variables defined above the current cursor position are targeted.

The details that are displayed when a completion item is selected are displayed using PHP reflection in the case of an object to identify what kind of object it is.

As a side note, there are other php-related regions in the blade file besides inline-php and php-directive, but I thought that I wouldn't define variables there, so I don't support them at the moment. The processing also needs a bit of work.

https://github.com/yaegassy/coc-laravel/assets/188642/1f9ec977-47f9-4650-9463-c97114049dbb

