### PR TITLE
feat: add use statement symbols to the php completion items

### DIFF
--- a/src/__tests__/phpCommon.test.ts
+++ b/src/__tests__/phpCommon.test.ts
@@ -284,3 +284,136 @@ class DateTime implements DateTimeInterface
   const expected = { start: 69, end: 96 };
   expect(itemRangeOffset).toMatchObject(expected);
 });
+
+test('Get symbol name data from use item', async () => {
+  //
+  // use My\Full\Classname;
+  //
+  const actual1 = phpCommon.getSymbolNameDataFromUseItem({
+    name: 'My\\Full\\ClassName',
+    startOffset: 10,
+    endOffset: 27,
+    groupStartOffset: 6,
+    groupEndOffset: 27,
+  })!;
+  const expected1 = {
+    qualifiedName: 'ClassName',
+    fullQualifiedName: 'My\\Full\\ClassName',
+    namespace: 'My\\Full',
+  };
+  expect(actual1).toMatchObject(expected1);
+
+  //
+  // use My\Full\Classname as Cls;
+  //
+  const actual2 = phpCommon.getSymbolNameDataFromUseItem({
+    name: 'My\\Full\\ClassName',
+    startOffset: 33,
+    endOffset: 57,
+    aliasName: 'Cls',
+    aliasStartOffset: 54,
+    aliasEndOffset: 57,
+    groupStartOffset: 29,
+    groupEndOffset: 57,
+  })!;
+  const expected2 = {
+    qualifiedName: 'ClassName',
+    fullQualifiedName: 'My\\Full\\ClassName',
+    aliasName: 'Cls',
+    namespace: 'My\\Full',
+  };
+  expect(actual2).toMatchObject(expected2);
+
+  //
+  // use My\Full\{Classname1};
+  //
+  const actual3 = phpCommon.getSymbolNameDataFromUseItem({
+    name: 'ClassName1',
+    startOffset: 72,
+    endOffset: 82,
+    groupName: 'My\\Full',
+    groupStartOffset: 59,
+    groupEndOffset: 83,
+  })!;
+  const expected3 = {
+    qualifiedName: 'ClassName1',
+    fullQualifiedName: 'My\\Full\\ClassName1',
+    namespace: 'My\\Full',
+  };
+  expect(actual3).toMatchObject(expected3);
+
+  //
+  // use My\Full\{Classname2, ClassName3};
+  //
+  const actual4x1 = phpCommon.getSymbolNameDataFromUseItem({
+    name: 'ClassName2',
+    startOffset: 98,
+    endOffset: 108,
+    groupName: 'My\\Full',
+    groupStartOffset: 85,
+    groupEndOffset: 121,
+  })!;
+  const actual4x2 = phpCommon.getSymbolNameDataFromUseItem({
+    name: 'ClassName3',
+    startOffset: 110,
+    endOffset: 120,
+    groupName: 'My\\Full',
+    groupStartOffset: 85,
+    groupEndOffset: 121,
+  })!;
+  const expected4x1 = {
+    qualifiedName: 'ClassName2',
+    fullQualifiedName: 'My\\Full\\ClassName2',
+    namespace: 'My\\Full',
+  };
+  const expected4x2 = {
+    qualifiedName: 'ClassName3',
+    fullQualifiedName: 'My\\Full\\ClassName3',
+    namespace: 'My\\Full',
+  };
+  expect(actual4x1).toMatchObject(expected4x1);
+  expect(actual4x2).toMatchObject(expected4x2);
+
+  //
+  // use My\Full\{Classname4 as Cls4, ClassName5 as Cls5};
+  //
+  const actual5x1 = phpCommon.getSymbolNameDataFromUseItem({
+    name: 'ClassName4',
+    startOffset: 136,
+    endOffset: 154,
+    aliasName: 'Cls4',
+    aliasStartOffset: 150,
+    aliasEndOffset: 154,
+    groupName: 'My\\Full',
+    groupStartOffset: 123,
+    groupEndOffset: 175,
+  })!;
+  const actual5x2 = phpCommon.getSymbolNameDataFromUseItem({
+    name: 'ClassName5',
+    startOffset: 156,
+    endOffset: 174,
+    aliasName: 'Cls5',
+    aliasStartOffset: 170,
+    aliasEndOffset: 174,
+    groupName: 'My\\Full',
+    groupStartOffset: 123,
+    groupEndOffset: 175,
+  })!;
+  const expected5x1 = {
+    qualifiedName: 'ClassName4',
+    fullQualifiedName: 'My\\Full\\ClassName4',
+    aliasName: 'Cls4',
+    namespace: 'My\\Full',
+  };
+  const expected5x2 = {
+    qualifiedName: 'ClassName5',
+    fullQualifiedName: 'My\\Full\\ClassName5',
+    aliasName: 'Cls5',
+    namespace: 'My\\Full',
+  };
+
+  expect(actual5x1).toMatchObject(expected5x1);
+  expect(actual5x2).toMatchObject(expected5x2);
+
+  // The behavior is similar for use function and use const.
+});

--- a/src/__tests__/phpParser.test.ts
+++ b/src/__tests__/phpParser.test.ts
@@ -515,3 +515,241 @@ foo("foo_param1")->bar('bar_param1', 'bar_param2')->baz('baz_param1');
   expect(callNameWithChainMethods[1].methods[0].arguments![1].startOffset).toEqual(112);
   expect(callNameWithChainMethods[1].methods[0].arguments![1].endOffset).toEqual(124);
 });
+
+test('Testing get use items', async () => {
+  const code = testUtils.stripInitialNewline(`
+<?php
+use My\\Full\\ClassName;
+use My\\Full\\ClassName as Cls;
+use My\\Full\\{ClassName1};
+use My\\Full\\{ClassName2, ClassName3};
+use My\\Full\\{ClassName4 as Cls4, ClassName5 as Cls5};
+use function My\\Full\\functionName;
+use function My\\Full\\functionName as func;
+use function My\\Full\\{functionName1};
+use function My\\Full\\{functionName2, functionName3};
+use function My\\Full\\{functionName4 as func4, functionName5 as func5};
+use const My\\Full\\CONSTANT;
+use const My\\Full\\CONSTANT as CONS;
+use const My\\Full\\{CONSTANT1};
+use const My\\Full\\{CONSTANT2, CONSTANT3};
+use const My\\Full\\{CONSTANT4 as CONS4, CONSTANT5 as CONS5};
+use ArrayObject;
+`);
+
+  const expected = [
+    {
+      name: 'My\\Full\\ClassName',
+      startOffset: 10,
+      endOffset: 27,
+      groupStartOffset: 6,
+      groupEndOffset: 27,
+    },
+    {
+      name: 'My\\Full\\ClassName',
+      startOffset: 33,
+      endOffset: 57,
+      aliasName: 'Cls',
+      aliasStartOffset: 54,
+      aliasEndOffset: 57,
+      groupStartOffset: 29,
+      groupEndOffset: 57,
+    },
+    {
+      name: 'ClassName1',
+      startOffset: 72,
+      endOffset: 82,
+      groupName: 'My\\Full',
+      groupStartOffset: 59,
+      groupEndOffset: 83,
+    },
+    {
+      name: 'ClassName2',
+      startOffset: 98,
+      endOffset: 108,
+      groupName: 'My\\Full',
+      groupStartOffset: 85,
+      groupEndOffset: 121,
+    },
+    {
+      name: 'ClassName3',
+      startOffset: 110,
+      endOffset: 120,
+      groupName: 'My\\Full',
+      groupStartOffset: 85,
+      groupEndOffset: 121,
+    },
+    {
+      name: 'ClassName4',
+      startOffset: 136,
+      endOffset: 154,
+      aliasName: 'Cls4',
+      aliasStartOffset: 150,
+      aliasEndOffset: 154,
+      groupName: 'My\\Full',
+      groupStartOffset: 123,
+      groupEndOffset: 175,
+    },
+    {
+      name: 'ClassName5',
+      startOffset: 156,
+      endOffset: 174,
+      aliasName: 'Cls5',
+      aliasStartOffset: 170,
+      aliasEndOffset: 174,
+      groupName: 'My\\Full',
+      groupStartOffset: 123,
+      groupEndOffset: 175,
+    },
+    {
+      name: 'My\\Full\\functionName',
+      startOffset: 190,
+      endOffset: 210,
+      groupType: 'function',
+      groupStartOffset: 177,
+      groupEndOffset: 210,
+    },
+    {
+      name: 'My\\Full\\functionName',
+      startOffset: 225,
+      endOffset: 253,
+      aliasName: 'func',
+      aliasStartOffset: 249,
+      aliasEndOffset: 253,
+      groupType: 'function',
+      groupStartOffset: 212,
+      groupEndOffset: 253,
+    },
+    {
+      name: 'functionName1',
+      startOffset: 277,
+      endOffset: 290,
+      groupName: 'My\\Full',
+      groupType: 'function',
+      groupStartOffset: 255,
+      groupEndOffset: 291,
+    },
+    {
+      name: 'functionName2',
+      startOffset: 315,
+      endOffset: 328,
+      groupName: 'My\\Full',
+      groupType: 'function',
+      groupStartOffset: 293,
+      groupEndOffset: 344,
+    },
+    {
+      name: 'functionName3',
+      startOffset: 330,
+      endOffset: 343,
+      groupName: 'My\\Full',
+      groupType: 'function',
+      groupStartOffset: 293,
+      groupEndOffset: 344,
+    },
+    {
+      name: 'functionName4',
+      startOffset: 368,
+      endOffset: 390,
+      aliasName: 'func4',
+      aliasStartOffset: 385,
+      aliasEndOffset: 390,
+      groupName: 'My\\Full',
+      groupType: 'function',
+      groupStartOffset: 346,
+      groupEndOffset: 415,
+    },
+    {
+      name: 'functionName5',
+      startOffset: 392,
+      endOffset: 414,
+      aliasName: 'func5',
+      aliasStartOffset: 409,
+      aliasEndOffset: 414,
+      groupName: 'My\\Full',
+      groupType: 'function',
+      groupStartOffset: 346,
+      groupEndOffset: 415,
+    },
+    {
+      name: 'My\\Full\\CONSTANT',
+      startOffset: 427,
+      endOffset: 443,
+      groupType: 'const',
+      groupStartOffset: 417,
+      groupEndOffset: 443,
+    },
+    {
+      name: 'My\\Full\\CONSTANT',
+      startOffset: 455,
+      endOffset: 479,
+      aliasName: 'CONS',
+      aliasStartOffset: 475,
+      aliasEndOffset: 479,
+      groupType: 'const',
+      groupStartOffset: 445,
+      groupEndOffset: 479,
+    },
+    {
+      name: 'CONSTANT1',
+      startOffset: 500,
+      endOffset: 509,
+      groupName: 'My\\Full',
+      groupType: 'const',
+      groupStartOffset: 481,
+      groupEndOffset: 510,
+    },
+    {
+      name: 'CONSTANT2',
+      startOffset: 531,
+      endOffset: 540,
+      groupName: 'My\\Full',
+      groupType: 'const',
+      groupStartOffset: 512,
+      groupEndOffset: 552,
+    },
+    {
+      name: 'CONSTANT3',
+      startOffset: 542,
+      endOffset: 551,
+      groupName: 'My\\Full',
+      groupType: 'const',
+      groupStartOffset: 512,
+      groupEndOffset: 552,
+    },
+    {
+      name: 'CONSTANT4',
+      startOffset: 573,
+      endOffset: 591,
+      aliasName: 'CONS4',
+      aliasStartOffset: 586,
+      aliasEndOffset: 591,
+      groupName: 'My\\Full',
+      groupType: 'const',
+      groupStartOffset: 554,
+      groupEndOffset: 612,
+    },
+    {
+      name: 'CONSTANT5',
+      startOffset: 593,
+      endOffset: 611,
+      aliasName: 'CONS5',
+      aliasStartOffset: 606,
+      aliasEndOffset: 611,
+      groupName: 'My\\Full',
+      groupType: 'const',
+      groupStartOffset: 554,
+      groupEndOffset: 612,
+    },
+    {
+      name: 'ArrayObject',
+      startOffset: 618,
+      endOffset: 629,
+      groupStartOffset: 614,
+      groupEndOffset: 629,
+    },
+  ];
+
+  const actual = phpParser.getUseItems(code);
+  expect(actual).toMatchObject(expected);
+});

--- a/src/common/php.ts
+++ b/src/common/php.ts
@@ -17,7 +17,7 @@ import {
   Variable,
 } from 'php-parser';
 
-import { PhpObjectItemType, StaticClassItemType } from '../common/types';
+import { PHPSymbolNameDataType, PHPUseItemType, PhpObjectItemType, StaticClassItemType } from '../common/types';
 import * as phpParser from '../parsers/php/parser';
 import { PHPClassItemKindEnum } from '../projects/types';
 
@@ -429,6 +429,27 @@ export function getObjectItemsFromPhpCode(code: string) {
   }, ast);
 
   return items;
+}
+
+export function getSymbolNameDataFromUseItem(item: PHPUseItemType) {
+  const qualifiedName = item.name.includes('\\') ? item.name.split('\\').pop() : item.name;
+  if (!qualifiedName) return;
+
+  const aliasName = item.aliasName;
+
+  const fullQualifiedName = item.groupName ? item.groupName + '\\' + item.name : item.name;
+  const namespace = fullQualifiedName.includes('\\')
+    ? fullQualifiedName.split('\\').slice(0, -1).join('\\')
+    : undefined;
+
+  const phpSymbolNameData: PHPSymbolNameDataType = {
+    qualifiedName,
+    fullQualifiedName,
+    aliasName,
+    namespace,
+  };
+
+  return phpSymbolNameData;
 }
 
 /**

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -15,8 +15,6 @@ export type ComposerJsonContentType = {
   };
 };
 
-export type PhpNamespaceType = { [key: string]: string };
-
 export type LivewireComponentMapType = {
   key: string;
   value: string;
@@ -65,6 +63,8 @@ export type BladeWithPhpStaticClassItemsType = {
   staticClassItems: StaticClassItemType[];
 };
 
+export type PhpNamespaceType = { [key: string]: string };
+
 export type PhpObjectItemType = {
   object: {
     name: string;
@@ -94,4 +94,24 @@ export type PhpVariableItemType = {
   bladeNodeStart?: number;
   bladeNodeEnd?: number;
   bladeNodeType?: PhpRelatedBladeNodeType;
+};
+
+export type PHPUseItemType = {
+  name: string;
+  startOffset: number;
+  endOffset: number;
+  aliasName?: string;
+  aliasStartOffset?: number;
+  aliasEndOffset?: number;
+  groupName?: string;
+  groupType?: string; // For class, groupType is undefined
+  groupStartOffset?: number;
+  groupEndOffset?: number;
+};
+
+export type PHPSymbolNameDataType = {
+  qualifiedName: string;
+  fullQualifiedName: string;
+  aliasName?: string;
+  namespace?: string;
 };

--- a/src/completions/handlers/phpClassHandler.ts
+++ b/src/completions/handlers/phpClassHandler.ts
@@ -48,7 +48,13 @@ export async function doCompletion(
     wordWithExtraChars = document.getText(wordWithExtraCharsRange);
   }
 
-  const phpUseStatementClassItems = getUseStatementPHPClassItems(code, phpClassProjectManager, position);
+  const phpUseStatementClassItems = getUseStatementPHPClassItems(
+    code,
+    phpClassProjectManager,
+    position,
+    offset,
+    wordWithExtraChars
+  );
   if (phpUseStatementClassItems.length > 0) {
     items.push(...phpUseStatementClassItems);
   }
@@ -128,11 +134,21 @@ function getPHPClassItems(
 function getUseStatementPHPClassItems(
   code: string,
   phpClassProjectManager: PHPClassProjectManagerType,
-  position: Position
+  position: Position,
+  editorOffset: number,
+  wordWithExtraChars?: string
 ) {
   const items: CompletionItem[] = [];
 
-  const virtualPhpEvalCode = bladeCommon.generateVirtualPhpEvalCode(code);
+  let evalCode = code;
+  if (wordWithExtraChars) {
+    const beforeInputString = code.slice(0, editorOffset - wordWithExtraChars.length);
+    const afterInputString = code.slice(editorOffset, code.length - 1);
+    const dummyString = "'__DUMMY__';";
+    evalCode = beforeInputString + dummyString + afterInputString;
+  }
+
+  const virtualPhpEvalCode = bladeCommon.generateVirtualPhpEvalCode(evalCode);
   if (!virtualPhpEvalCode) return [];
 
   const useItems = phpParser.getUseItems('<?php\n' + virtualPhpEvalCode);

--- a/src/completions/handlers/phpClassHandler.ts
+++ b/src/completions/handlers/phpClassHandler.ts
@@ -14,8 +14,10 @@ import {
 import fs from 'fs';
 import path from 'path';
 
+import * as bladeCommon from '../../common/blade';
 import * as phpCommon from '../../common/php';
 import { STUBS_VENDOR_NAME } from '../../constant';
+import * as phpParser from '../../parsers/php/parser';
 import { type PHPClassProjectManagerType } from '../../projects/types';
 import * as phpClassCompletionService from '../services/phpClassService';
 import { CompletionItemDataType } from '../types';
@@ -44,6 +46,11 @@ export async function doCompletion(
   );
   if (wordWithExtraCharsRange) {
     wordWithExtraChars = document.getText(wordWithExtraCharsRange);
+  }
+
+  const phpUseStatementClassItems = getUseStatementPHPClassItems(code, phpClassProjectManager, position);
+  if (phpUseStatementClassItems.length > 0) {
+    items.push(...phpUseStatementClassItems);
   }
 
   const phpClassItems = getPHPClassItems(phpClassProjectManager, position, wordWithExtraChars, context);
@@ -118,6 +125,64 @@ function getPHPClassItems(
   return items;
 }
 
+function getUseStatementPHPClassItems(
+  code: string,
+  phpClassProjectManager: PHPClassProjectManagerType,
+  position: Position
+) {
+  const items: CompletionItem[] = [];
+
+  const virtualPhpEvalCode = bladeCommon.generateVirtualPhpEvalCode(code);
+  if (!virtualPhpEvalCode) return [];
+
+  const useItems = phpParser.getUseItems('<?php\n' + virtualPhpEvalCode);
+  if (useItems.length === 0) return [];
+
+  for (const item of useItems) {
+    // For class, groupType is undefined
+    if (item.groupType) continue;
+
+    const symbolNameData = phpCommon.getSymbolNameDataFromUseItem(item);
+    if (!symbolNameData) continue;
+
+    const storeData = phpClassProjectManager.phpClassMapStore.get(symbolNameData.fullQualifiedName);
+    if (!storeData) continue;
+
+    const edit: TextEdit = {
+      range: {
+        start: position,
+        end: position,
+      },
+      newText: symbolNameData.aliasName ? symbolNameData.aliasName : symbolNameData.qualifiedName,
+    };
+
+    const data: CompletionItemDataType = {
+      source: 'laravel-php-class',
+      filePath: storeData.path,
+      isStubs: storeData.isStubs,
+      kind: storeData.kind,
+      qualifiedName: symbolNameData.qualifiedName,
+      fullQualifiedName: symbolNameData.fullQualifiedName,
+      namespace: symbolNameData.namespace,
+    };
+
+    const kind = phpClassCompletionService.getCompletionItemKindAtClassItemKind(storeData.kind);
+
+    items.push({
+      label: symbolNameData.aliasName ? symbolNameData.aliasName : symbolNameData.qualifiedName,
+      labelDetails: symbolNameData.namespace
+        ? { description: `[${symbolNameData.namespace}]` }
+        : { description: '[from use statement]' },
+      kind,
+      insertTextFormat: InsertTextFormat.PlainText,
+      textEdit: edit,
+      data,
+    });
+  }
+
+  return items;
+}
+
 export async function doResolveCompletionItem(
   item: CompletionItem,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -146,17 +211,26 @@ export async function doResolveCompletionItem(
 
   const targetPHPCode = await fs.promises.readFile(absoluteItemDataFilePath, { encoding: 'utf8' });
 
-  const itemShortName = item.label.includes('\\') ? item.label.split('\\').pop() : item.label;
-  if (!itemShortName) return item;
+  let itemQualifiedName: string | undefined = undefined;
+  if (itemData.qualifiedName) {
+    itemQualifiedName = itemData.qualifiedName;
+  } else {
+    itemQualifiedName = item.label.includes('\\') ? item.label.split('\\').pop() : item.label;
+  }
+  if (!itemQualifiedName) return item;
 
   const itemKindName = phpCommon.getClassItemKindName(itemData.kind);
 
-  const itemStartOffset = phpCommon.getClassItemStartOffsetFromPhpCode(targetPHPCode, itemShortName, itemKindName);
+  const itemStartOffset = phpCommon.getClassItemStartOffsetFromPhpCode(targetPHPCode, itemQualifiedName, itemKindName);
   if (!itemStartOffset) return item;
 
   const defineString = phpCommon.getDefinitionStringByStartOffsetFromPhpCode(targetPHPCode, itemStartOffset);
 
-  const itemDocumentation = phpCommon.getClassItemDocumantationFromPhpCode(targetPHPCode, itemShortName, itemKindName);
+  const itemDocumentation = phpCommon.getClassItemDocumantationFromPhpCode(
+    targetPHPCode,
+    itemQualifiedName,
+    itemKindName
+  );
 
   let documentationValue = '';
   documentationValue += '```php\n<?php\n';

--- a/src/completions/handlers/phpFunctionHandler.ts
+++ b/src/completions/handlers/phpFunctionHandler.ts
@@ -51,7 +51,13 @@ export async function doCompletion(
     wordWithExtraChars = document.getText(wordWithExtraCharsRange);
   }
 
-  const phpUseStatementFunctionItems = getUseStatementPHPFunctionItems(code, phpFunctionProjectManager, position);
+  const phpUseStatementFunctionItems = getUseStatementPHPFunctionItems(
+    code,
+    phpFunctionProjectManager,
+    position,
+    offset,
+    wordWithExtraChars
+  );
   if (phpUseStatementFunctionItems.length > 0) {
     items.push(...phpUseStatementFunctionItems);
   }
@@ -129,11 +135,20 @@ function getUseStatementPHPFunctionItems(
   code: string,
   phpFunctionProjectManager: PHPFunctionProjectManagerType,
   position: Position,
+  editorOffset: number,
   wordWithExtraChars?: string
 ) {
   const items: CompletionItem[] = [];
 
-  const virtualPhpEvalCode = bladeCommon.generateVirtualPhpEvalCode(code);
+  let evalCode = code;
+  if (wordWithExtraChars) {
+    const beforeInputString = code.slice(0, editorOffset - wordWithExtraChars.length);
+    const afterInputString = code.slice(editorOffset, code.length - 1);
+    const dummyString = "'__DUMMY__';";
+    evalCode = beforeInputString + dummyString + afterInputString;
+  }
+
+  const virtualPhpEvalCode = bladeCommon.generateVirtualPhpEvalCode(evalCode);
   if (!virtualPhpEvalCode) return [];
 
   const useItems = phpParser.getUseItems('<?php\n' + virtualPhpEvalCode);

--- a/src/completions/services/phpConstantService.ts
+++ b/src/completions/services/phpConstantService.ts
@@ -20,6 +20,12 @@ export function canCompletionFromContext(code: string, editorOffset: number) {
   flags.push(isEditorOffsetInDirectiveWithParametersRegionOfPhpNodeKind(code, editorOffset, 'name'));
   flags.push(isEditorOffsetInPropsValueRegionOfPhpNodeKind(code, editorOffset, 'name'));
 
+  flags.push(isEditorOffsetInBladeEchoRegionOfPhpNodeKind(code, editorOffset, 'useitem'));
+  flags.push(isEditorOffsetInPHPDirectiveRegionOfPhpNodeKind(code, editorOffset, 'useitem'));
+  flags.push(isEditorOffsetInInlinePHPRegionOfPhpNodeKind(code, editorOffset, 'useitem'));
+  flags.push(isEditorOffsetInDirectiveWithParametersRegionOfPhpNodeKind(code, editorOffset, 'useitem'));
+  flags.push(isEditorOffsetInPropsValueRegionOfPhpNodeKind(code, editorOffset, 'useitem'));
+
   if (flags.includes(true)) {
     return true;
   } else {

--- a/src/completions/types.ts
+++ b/src/completions/types.ts
@@ -20,7 +20,7 @@ export type RangeOffset = {
 };
 
 export type CompletionItemDataType = {
-  source: CompletionItemSource;
+  source: CompletionItemSource; // ALL
   filePath?: string; // phpConstant, phpFunction, phpClass, phpStaticClass
   kind?: PHPClassItemKindEnum; // phpClass, phpStaticClass
   isStubs?: boolean; // phpConstant, phpFunction, phpClass, phpStaticClass
@@ -29,6 +29,9 @@ export type CompletionItemDataType = {
   originalContent?: string; // phpVariable
   objectName?: string; // phpObjectMember
   virtualContent?: string; // phpObjectMember
+  namespace?: string; // phpClass, phpFunction
+  qualifiedName?: string; // phpClass, phpFunction
+  fullQualifiedName?: string; // phpClass, phpFunction
 };
 
 type CompletionItemSource =


### PR DESCRIPTION
support for classes and functions in `use` statements. alias is also supported. `use const` was not supported

**DEMO (mp4)**:

https://github.com/yaegassy/coc-laravel/assets/188642/5c0d38ef-adbd-4a80-aabd-8441a5aadaf5

